### PR TITLE
Mise à jour des règles pour la JSdoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,12 +16,13 @@ module.exports = {
     'comma-dangle': ['error', 'always-multiline'],
     'require-jsdoc': [
       'error', {
-      'require': {
-        'FunctionDeclaration': true,
-        'MethodDefinition': false,
-        'ClassDeclaration': true,
+        'require': {
+          'FunctionDeclaration': true,
+          'MethodDefinition': false,
+          'ClassDeclaration': true,
+        },
       },
-    }],
+    ],
     'valid-jsdoc': ['error', { requireReturn: false }],
     'new-cap': [
       'error', {

--- a/index.js
+++ b/index.js
@@ -16,13 +16,13 @@ module.exports = {
     'comma-dangle': ['error', 'always-multiline'],
     'require-jsdoc': [
       'error', {
-        'require': {
-          'FunctionDeclaration': true,
-          'MethodDefinition': true,
-          'ClassDeclaration': true,
-        },
-      }],
-    'valid-jsdoc': 'error',
+      'require': {
+        'FunctionDeclaration': true,
+        'MethodDefinition': false,
+        'ClassDeclaration': true,
+      },
+    }],
+    'valid-jsdoc': ['error', { requireReturn: false }],
     'new-cap': [
       'error', {
         capIsNewExceptions: ['Polymer'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udes",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "ESLint shareable config for the UdeS JavaScript style guide",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
J'ai intégré le package pour remplacer le eslint de airbnb dans l'orchestrateur et j'ai remarqué des problèmes avec les règles de JSDoc qui rentre en conflit avec la génération de documentation html. Je suggère donc 2 changements:
- Ne pas obliger le tag return si le fonction ne retourne rien.
- Ne pas obliger la documentation des constructeurs des classes (plutot écrire la documentation du constructeur au dessus de la déclaration de la classe)