### PR TITLE
Refonte majeure de eslint-config-udes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# Top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+trim_trailing_whitespace = true
+
+[*.php]
+indent_size = 4

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Université de Sherbrooke
+Copyright (c) 2017-2018 Université de Sherbrooke
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,43 +1,64 @@
 # eslint-config-udes
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/UdeS-STI/eslint-config-udes.svg)](https://greenkeeper.io/)
 [![CircleCI](https://circleci.com/gh/UdeS-STI/eslint-config-udes.svg?style=svg)](https://circleci.com/gh/UdeS-STI/eslint-config-udes)
+[![Greenkeeper badge](https://badges.greenkeeper.io/UdeS-STI/eslint-config-udes.svg)](https://greenkeeper.io/)
 [![npm](https://img.shields.io/npm/v/eslint-config-udes.svg?style=flat-square)](https://www.npmjs.com/package/eslint-config-udes)
 
-ESLint shareable config for the UdeS JavaScript style guide
+ESLint shareable config for the UdeS JavaScript style guide.
 
 ## Installation
 ```bash
-$ npm i -D eslint-config-udes
+$ npm install eslint-config-udes --save-dev
 ```
 
 ## Usage
-- Add the extends attribute to your `.eslintrc.js`
+- Add the extends attribute to your `.eslintrc.js`:
+
 ```javacript
 module.exports = {
   // Extends the UdeS ESLint config
   extends: 'eslint-config-udes',
   
   // Limit ESLint to a specific project
-  root: true
+  root: true,
 }
 ```
-- Add the wanted scripts to your `package.json`
+
+- If you use one of the supported language/framework, you should use the corresponding extends:
+```
+  // Extends the UdeS ESLint config for Polymer 2 application
+  extends: 'eslint-config-udes/polymer-2-application',
+  
+  // Extends the UdeS ESLint config for Polymer 2 element
+  extends: 'eslint-config-udes/polymer-2-element',
+  
+  // Extends the UdeS ESLint config for Node.js 8 application
+  extends: 'eslint-config-udes/node-8',
+  
+  // Extends the UdeS ESLint config for React application and element
+  extends: 'eslint-config-udes/react',
+```
+
+- Add the wanted scripts to your `package.json`:
+
 ```json
 { 
   "scripts": {
-    "format": "npm run format:js && npm run format:json",
-    "format:js": "eslint . --ext js,html --ignore-path .gitignore --fix",
-    "format:json": "eslint . --ext .json --ignore-path .gitignore --fix",
-    "lint": "npm run lint:js && npm run lint:json && npm run lint:polymer",
-    "lint:js": "eslint . --ext js,html --ignore-path .gitignore",
-    "lint:json": "eslint . --ext .json --ignore-path .gitignore",
-    "lint:polymer": "polymer lint"
-  },
-  "pre-commit": [
-      "lint"
-    ]
+    "format": "npm-run-all format:*",
+    "format:js": "eslint . --ext js --fix",
+    "format:json": "eslint . --ext json --fix",
+    "format:markdown": "eslint . --ext md --fix",
+    "lint": "npm-run-all lint:*",
+    "lint:js": "eslint . --ext js",
+    "lint:json": "eslint . --ext json",
+    "lint:markdown": "eslint . --ext md"
+  }
 }
+```
+
+- If you use the `npm-run-all` module, don't forget to add it to your devDependencies:
+```bash
+npm install npm-run-all --save-dev
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 module.exports = {
   // Extends the JavaScript Standard Style
-  extends: ['eslint-config-standard'],
+  extends: [
+    'eslint:recommended',
+    'google',
+  ],
 
+  // Supported JavaScript language options
   parserOptions: {
     // Enables ES6/ES2015 syntax
     ecmaVersion: 6,
@@ -9,86 +13,53 @@ module.exports = {
 
   // Defines global variables that are predefined
   env: {
-    // Browser global variables
-    browser: true,
-
     // Enable ES6 features (automatically sets the ecmaVersion parser option to 6)
     es6: true,
-
-    // Node.js global variables and Node.js scoping
-    node: true,
   },
 
   // Use of third-party plugins
   plugins: [
-    // Allows linting and fixing inline scripts contained in HTML files
-    'eslint-plugin-html',
-
     // Lint JSON files
     'eslint-plugin-json',
+
+    // Lint markdown files
+    'eslint-plugin-markdown',
   ],
 
   // Custom rules
   rules: {
     // Requires trailing commas when the last element or property is in a different line than the closing ] or }
-    'comma-dangle': ['error', {
-      'arrays': 'always-multiline', // let [a,] = [1,]
-      'exports': 'always-multiline', // export {a,}
+    'comma-dangle': [
+      'error', {
+        'arrays': 'always-multiline', // let [a,] = [1,]
+        'exports': 'always-multiline', // export {a,}
 
-      // Should only be enabled when linting ECMAScript 2017 (ES8) or higher
-      'functions': 'ignore', // (function(a,){ })(b,)
+        // Should only be enabled when linting ECMAScript 2017 (ES8) or higher
+        'functions': 'ignore', // (function(a,){ })(b,)
 
-      'imports': 'always-multiline', // import {a,} from "foo"
-      'objects': 'always-multiline', // let {a,} = {a: 1}
-    }],
+        'imports': 'always-multiline', // import {a,} from "foo"
+        'objects': 'always-multiline', // let {a,} = {a: 1}
+      }],
+
+    // Enforces at least one newline  at the end of non-empty files
+    'eol-last': ['error', 'always'],
+
+    // Consistent indentation style
+    'indent': ['error', 2],
+
+    // Consistent line endings independent of operating system, VCS, or editor used across your codebase (default: unix)
+    'linebreak-style': ['error', 'unix'],
 
     // Enforce a maximum line length of 120 characters (instead of 80 from Standard) [See pull request #4]
     'max-len': ['error', 120],
 
-    // Require constructor names to begin with a capital letter
-    'new-cap': [
-      'error', {
-        // Allows specified uppercase-started function names to be called without the new operator
-        capIsNewExceptions: ['Polymer'],
-
-        // Allows any uppercase-started function names that match the specified regex pattern to be called without the
-        // new operator
-        capIsNewExceptionPattern: '^(UdeS|Polymer)',
-      }],
+    // Disallow trailing spaces at the end of lines
+    'no-trailing-spaces': 'error',
 
     // Disallow the use of console [See pull request #2]
     'no-console': 'warn',
 
-    // Require JSDoc comments
-    'require-jsdoc': [
-      'error', {
-        // Requires JSDoc comments for the specified nodes
-        'require': {
-          // Class Foo
-          'ClassDeclaration': true,
-
-          // function foo() {}
-          'FunctionDeclaration': true,
-
-          // constructor() {} [See pull request #1]
-          'MethodDefinition': false,
-        },
-      },
-    ],
-
-    // Enforce valid JSDoc comments
-    'valid-jsdoc': ['error', {
-      // If and only if the function or method has a return statement [See pull request #1]
-      requireReturn: false,
-    }],
+    // Require or disallow semicolons instead of ASI
+    'semi': ['error', 'always'],
   },
-
-  // Variables that are accessed but not defined within the same file
-  globals: {
-    // UdeS components and global scoped variables
-    UdeS: true,
-
-    // UdeS components and global scoped variables
-    Polymer: true,
-  },
-}
+};

--- a/index.js
+++ b/index.js
@@ -28,6 +28,13 @@ module.exports = {
 
   // Custom rules
   rules: {
+    // Enforces parentheses around arrow function parameters regardless of arity
+    'arrow-parens': [
+      'error', 'as-needed', {
+        // Require parens if the function body is in an instructions block
+        requireForBlockBody: true,
+      }],
+
     // Requires trailing commas when the last element or property is in a different line than the closing ] or }
     'comma-dangle': [
       'error', {
@@ -45,7 +52,11 @@ module.exports = {
     'eol-last': ['error', 'always'],
 
     // Consistent indentation style
-    'indent': ['error', 2],
+    'indent': [
+      'error', 2, {
+        // Indent case clauses with 2 spaces with respect to switch statements
+        SwitchCase: 1,
+      }],
 
     // Consistent line endings independent of operating system, VCS, or editor used across your codebase (default: unix)
     'linebreak-style': ['error', 'unix'],
@@ -58,6 +69,9 @@ module.exports = {
 
     // Disallow the use of console [See pull request #2]
     'no-console': 'warn',
+
+    // enforce consistent spacing inside braces
+    'object-curly-spacing': ['error', 'always'],
 
     // Override from Google
     // https://github.com/google/eslint-config-google/blob/394bf3c9f858b83514fdcbf23d74492e253d611f/index.js#L269-L275

--- a/index.js
+++ b/index.js
@@ -59,7 +59,15 @@ module.exports = {
     // Disallow the use of console [See pull request #2]
     'no-console': 'warn',
 
+    // Override from Google
+    // https://github.com/google/eslint-config-google/blob/394bf3c9f858b83514fdcbf23d74492e253d611f/index.js#L269-L275
+    'require-jsdoc': 'off',
+
     // Require or disallow semicolons instead of ASI
     'semi': ['error', 'always'],
+
+    // Override from Google
+    // https://github.com/google/eslint-config-google/blob/394bf3c9f858b83514fdcbf23d74492e253d611f/index.js#L65-L70
+    'valid-jsdoc': 'off',
   },
 };

--- a/node-8.js
+++ b/node-8.js
@@ -4,12 +4,18 @@ module.exports = {
     './index.js',
   ],
 
+  // Supported JavaScript language options
+  parserOptions: {
+    // Enables ES7/ES2016 syntax
+    ecmaVersion: 7,
+  },
+
   // Defines global variables that are predefined
   env: {
+    // Enable ES6 features (automatically sets the ecmaVersion parser option to 6)
+    es6: true,
+
     // Node.js global variables and Node.js scoping
     node: true,
   },
-
-  // Limit ESLint to a specific project
-  root: true,
 };

--- a/node-8.js
+++ b/node-8.js
@@ -8,6 +8,9 @@ module.exports = {
   parserOptions: {
     // Enables ES7/ES2016 syntax
     ecmaVersion: 7,
+
+    // Code is in ECMAScript modules (default: script)
+    sourceType: 'module',
   },
 
   // Defines global variables that are predefined

--- a/node-8.js
+++ b/node-8.js
@@ -6,8 +6,8 @@ module.exports = {
 
   // Supported JavaScript language options
   parserOptions: {
-    // Enables ES7/ES2016 syntax
-    ecmaVersion: 7,
+    // Enables ES8/ES2017 syntax
+    ecmaVersion: 8,
 
     // Code is in ECMAScript modules (default: script)
     sourceType: 'module',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "eslint-config-udes",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+      "version": "5.4.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/acorn/-/acorn-5.4.1.tgz",
+      "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -25,9 +25,9 @@
       }
     },
     "ajv": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+      "version": "5.5.2",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
@@ -63,6 +63,33 @@
         "sprintf-js": "1.0.3"
       }
     },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
+      }
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+      "dev": true
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+      "dev": true
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -80,6 +107,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -113,6 +145,11 @@
         }
       }
     },
+    "bail": {
+      "version": "1.0.2",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/bail/-/bail-1.0.2.tgz",
+      "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -129,8 +166,9 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
@@ -173,6 +211,26 @@
         }
       }
     },
+    "character-entities": {
+      "version": "1.2.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/character-entities/-/character-entities-1.2.1.tgz",
+      "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
+      "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8="
+    },
+    "character-reference-invalid": {
+      "version": "1.1.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
+      "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw="
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+    },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
@@ -204,6 +262,11 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "collapse-white-space": {
+      "version": "1.0.3",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
+      "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw="
     },
     "color-convert": {
       "version": "1.9.1",
@@ -241,10 +304,10 @@
         "date-now": "0.1.4"
       }
     },
-    "contains-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -279,6 +342,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
@@ -294,12 +366,11 @@
       }
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.1.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "2.0.2"
       }
     },
     "dom-serializer": {
@@ -340,6 +411,20 @@
         "domelementtype": "1.3.0"
       }
     },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
@@ -347,10 +432,33 @@
     },
     "error-ex": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.10.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/es-abstract/-/es-abstract-1.10.0.tgz",
+      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -359,34 +467,34 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.10.0.tgz",
-      "integrity": "sha512-MMVl8P/dYUFZEvolL8PYt7qc5LNdS2lwheq9BYa5Y07FblhcZqFyaUqlS8TW5QITGex21tV4Lk0a3fK8lsJIkA==",
+      "version": "4.17.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/eslint/-/eslint-4.17.0.tgz",
+      "integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
       "requires": {
-        "ajv": "5.3.0",
+        "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
         "chalk": "2.3.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
-        "doctrine": "2.0.0",
+        "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.3",
         "esquery": "1.0.0",
-        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "9.18.0",
+        "globals": "11.3.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
-        "is-resolvable": "1.0.0",
+        "is-resolvable": "1.1.0",
         "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
@@ -402,92 +510,17 @@
         "text-table": "0.2.0"
       }
     },
-    "eslint-config-standard": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
-      "integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE="
-    },
-    "eslint-import-resolver-node": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
-      "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
-      "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.5.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "eslint-module-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
-      "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
+    "eslint-config-google": {
+      "version": "0.9.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/eslint-config-google/-/eslint-config-google-0.9.1.tgz",
+      "integrity": "sha512-5A83D+lH0PA81QMESKbLJd/a3ic8tPZtwUmqNrxMRo54nfFaUvtt89q/+icQ+fd66c2xQHn0KyFkzJDoAUfpZA=="
     },
     "eslint-plugin-html": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-3.2.2.tgz",
-      "integrity": "sha512-sSuafathF6ImPrzF2vUKEJY6Llq06d/riMTMzlsruDRDhNsQMYp2viUKo+jx+JRr1QevskeUpQcuptp2gN1XVQ==",
+      "version": "4.0.2",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/eslint-plugin-html/-/eslint-plugin-html-4.0.2.tgz",
+      "integrity": "sha512-CrQd0F8GWdNWnu4PFrYZl+LjUCXNVy2h0uhDMtnf/7VKc9HRcnkXSrlg0BSGfptZPSzmwnnwCaREAa9+fnQhYw==",
       "requires": {
-        "htmlparser2": "3.9.2",
-        "semver": "5.4.1"
-      }
-    },
-    "eslint-plugin-import": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-      "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
-      "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
-        "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.1",
-        "eslint-module-utils": "2.1.1",
-        "has": "1.0.1",
-        "lodash.cond": "4.5.2",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          }
-        }
+        "htmlparser2": "3.9.2"
       }
     },
     "eslint-plugin-json": {
@@ -498,33 +531,26 @@
         "jshint": "2.9.5"
       }
     },
-    "eslint-plugin-node": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
-      "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
+    "eslint-plugin-markdown": {
+      "version": "1.0.0-beta.6",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/eslint-plugin-markdown/-/eslint-plugin-markdown-1.0.0-beta.6.tgz",
+      "integrity": "sha1-2eYmZu6k52OH6F9QLfZoq9+9Q5U=",
       "requires": {
-        "ignore": "3.3.7",
-        "minimatch": "3.0.4",
-        "resolve": "1.5.0",
-        "semver": "5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
-        }
+        "object-assign": "4.1.1",
+        "remark-parse": "3.0.1",
+        "unified": "6.1.6"
       }
     },
-    "eslint-plugin-promise": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz",
-      "integrity": "sha512-YQzM6TLTlApAr7Li8vWKR+K3WghjwKcYzY0d2roWap4SLK+kzuagJX/leTetIDWsFcTFnKNJXWupDCD6aZkP2Q=="
-    },
-    "eslint-plugin-standard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-      "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI="
+    "eslint-plugin-react": {
+      "version": "7.6.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/eslint-plugin-react/-/eslint-plugin-react-7.6.1.tgz",
+      "integrity": "sha512-30aMOHWX/DOaaLJVBHz6RMvYM2qy5GH63+y2PLFdIrYe4YLtODFmT3N1YA7ZqUnaBweVbedr4K4cqxOlWAPjIw==",
+      "requires": {
+        "doctrine": "2.1.0",
+        "has": "1.0.1",
+        "jsx-ast-utils": "2.0.1",
+        "prop-types": "15.6.0"
+      }
     },
     "eslint-scope": {
       "version": "3.7.1",
@@ -535,12 +561,17 @@
         "estraverse": "4.2.0"
       }
     },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+    },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.3",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/espree/-/espree-3.5.3.tgz",
+      "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.4.1",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -576,18 +607,38 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
+      }
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
     },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
     "external-editor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "version": "2.1.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "requires": {
+        "chardet": "0.4.2",
         "iconv-lite": "0.4.19",
-        "jschardet": "1.6.0",
         "tmp": "0.0.33"
       }
     },
@@ -606,6 +657,20 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.17"
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -623,15 +688,6 @@
         "object-assign": "4.1.1"
       }
     },
-    "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
-      }
-    },
     "flat-cache": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
@@ -642,6 +698,17 @@
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -672,9 +739,9 @@
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "version": "11.3.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/globals/-/globals-11.3.0.tgz",
+      "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw=="
     },
     "globby": {
       "version": "5.0.0",
@@ -717,8 +784,9 @@
     },
     "hosted-git-info": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
     },
     "htmlparser2": {
       "version": "3.9.2",
@@ -771,9 +839,9 @@
         "chalk": "2.3.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
+        "external-editor": "2.1.0",
         "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -783,23 +851,64 @@
         "through": "2.3.8"
       }
     },
+    "is-alphabetical": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
+      "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg="
+    },
+    "is-alphanumerical": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
+      "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
+      "requires": {
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-decimal": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-decimal/-/is-decimal-1.0.1.tgz",
+      "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-hexadecimal": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
+      "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk="
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -811,29 +920,59 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
         "path-is-inside": "1.0.2"
       }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
-    "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "tryit": "1.0.3"
+        "has": "1.0.1"
       }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+    },
+    "is-whitespace-character": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz",
+      "integrity": "sha1-muAXbzKCtlRXoZks2whPil+DPjs="
+    },
+    "is-word-character": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-word-character/-/is-word-character-1.0.1.tgz",
+      "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs="
     },
     "isarray": {
       "version": "1.0.0",
@@ -844,6 +983,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      }
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -858,11 +1006,6 @@
         "argparse": "1.0.9",
         "esprima": "4.0.0"
       }
-    },
-    "jschardet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
-      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
     },
     "jshint": {
       "version": "2.9.5",
@@ -946,23 +1089,35 @@
         }
       }
     },
+    "json-parse-better-errors": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
-    "json-stable-stringify": {
+    "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsx-ast-utils": {
+      "version": "2.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "requires": {
+        "array-includes": "3.0.3"
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -974,41 +1129,37 @@
       }
     },
     "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "version": "4.0.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
         "strip-bom": "3.0.0"
-      }
-    },
-    "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
       },
       "dependencies": {
-        "path-exists": {
+        "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+          "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         }
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.5",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
-    "lodash.cond": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
     },
     "lru-cache": {
       "version": "4.1.1",
@@ -1019,10 +1170,27 @@
         "yallist": "2.1.2"
       }
     },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
+    },
+    "markdown-escapes": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/markdown-escapes/-/markdown-escapes-1.0.1.tgz",
+      "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg="
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
+    },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+      "version": "1.2.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1060,10 +1228,20 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
     "normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
@@ -1071,10 +1249,43 @@
         "validate-npm-package-license": "3.0.1"
       }
     },
+    "npm-run-all": {
+      "version": "4.1.2",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/npm-run-all/-/npm-run-all-4.1.2.tgz",
+      "integrity": "sha512-Z2aRlajMK4SQ8u19ZA75NZZu7wupfCNQWdYosIi8S6FgBdGf/8Y6Hgyjdc8zU2cYmIRVCx1nM80tJPkdEd+UYg==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.0",
+        "chalk": "2.3.0",
+        "cross-spawn": "5.1.0",
+        "memorystream": "0.3.1",
+        "minimatch": "3.0.4",
+        "ps-tree": "1.1.0",
+        "read-pkg": "3.0.0",
+        "shell-quote": "1.6.1",
+        "string.prototype.padend": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
     "once": {
       "version": "1.4.0",
@@ -1089,7 +1300,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optionator": {
@@ -1105,44 +1316,32 @@
         "wordwrap": "1.0.0"
       }
     },
-    "os-shim": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
-      "dev": true
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
-    "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
-    },
-    "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+    "parse-entities": {
+      "version": "1.1.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/parse-entities/-/parse-entities-1.1.1.tgz",
+      "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
       "requires": {
-        "p-limit": "1.1.0"
+        "character-entities": "1.2.1",
+        "character-entities-legacy": "1.1.1",
+        "character-reference-invalid": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-hexadecimal": "1.0.1"
       }
     },
     "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "version": "4.0.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
-      }
-    },
-    "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "requires": {
-        "pinkie-promise": "2.0.1"
+        "error-ex": "1.3.1",
+        "json-parse-better-errors": "1.0.1"
       }
     },
     "path-is-absolute": {
@@ -1155,17 +1354,30 @@
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
-    "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
-    },
     "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "version": "3.0.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
       }
     },
     "pify": {
@@ -1186,40 +1398,10 @@
         "pinkie": "2.0.4"
       }
     },
-    "pkg-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "requires": {
-        "find-up": "1.1.2"
-      }
-    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
-    },
-    "pre-commit": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
-      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "spawn-sync": "1.0.15",
-        "which": "1.2.14"
-      },
-      "dependencies": {
-        "which": {
-          "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          }
-        }
-      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -1236,38 +1418,47 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "ps-tree": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/ps-tree/-/ps-tree-1.1.0.tgz",
+      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+      "dev": true,
+      "requires": {
+        "event-stream": "3.3.4"
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "version": "3.0.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
+        "load-json-file": "4.0.0",
         "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        }
+        "path-type": "3.0.0"
       }
     },
     "readable-stream": {
@@ -1284,6 +1475,39 @@
         "util-deprecate": "1.0.2"
       }
     },
+    "remark-parse": {
+      "version": "3.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/remark-parse/-/remark-parse-3.0.1.tgz",
+      "integrity": "sha1-G5+EGkTY9PvyJGhQJlRZpOs1TIA=",
+      "requires": {
+        "collapse-white-space": "1.0.3",
+        "has": "1.0.1",
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-whitespace-character": "1.0.1",
+        "is-word-character": "1.0.1",
+        "markdown-escapes": "1.0.1",
+        "parse-entities": "1.1.1",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "1.1.0",
+        "unherit": "1.1.0",
+        "unist-util-remove-position": "1.1.1",
+        "vfile-location": "2.0.2",
+        "xtend": "4.0.1"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -1291,14 +1515,6 @@
       "requires": {
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
-      }
-    },
-    "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-      "requires": {
-        "path-parse": "1.0.5"
       }
     },
     "resolve-from": {
@@ -1354,6 +1570,11 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
       "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -1366,6 +1587,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "dev": true,
+      "requires": {
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
+      }
     },
     "shelljs": {
       "version": "0.3.0",
@@ -1385,38 +1618,54 @@
         "is-fullwidth-code-point": "2.0.0"
       }
     },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.6.0",
-        "os-shim": "0.1.3"
-      }
-    },
     "spdx-correct": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
     },
     "spdx-license-ids": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "state-toggle": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/state-toggle/-/state-toggle-1.0.0.tgz",
+      "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU="
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1"
+      }
     },
     "string-width": {
       "version": "2.1.1",
@@ -1425,6 +1674,17 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string.prototype.padend": {
+      "version": "3.0.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
@@ -1452,8 +1712,9 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -1470,10 +1731,10 @@
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "requires": {
-        "ajv": "5.3.0",
+        "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
         "chalk": "2.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       }
@@ -1496,10 +1757,20 @@
         "os-tmpdir": "1.0.2"
       }
     },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
+      "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ="
+    },
+    "trough": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/trough/-/trough-1.0.1.tgz",
+      "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y="
     },
     "type-check": {
       "version": "0.3.2",
@@ -1514,6 +1785,60 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "ua-parser-js": {
+      "version": "0.7.17",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+    },
+    "unherit": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/unherit/-/unherit-1.1.0.tgz",
+      "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
+      "requires": {
+        "inherits": "2.0.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "unified": {
+      "version": "6.1.6",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/unified/-/unified-6.1.6.tgz",
+      "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
+      "requires": {
+        "bail": "1.0.2",
+        "extend": "3.0.1",
+        "is-plain-obj": "1.1.0",
+        "trough": "1.0.1",
+        "vfile": "2.3.0",
+        "x-is-function": "1.0.4",
+        "x-is-string": "0.1.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "2.1.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/unist-util-is/-/unist-util-is-2.1.1.tgz",
+      "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs="
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz",
+      "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
+      "requires": {
+        "unist-util-visit": "1.3.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "1.1.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz",
+      "integrity": "sha1-PMvcU2ee7W7PN3fdf14yKcG2qjw="
+    },
+    "unist-util-visit": {
+      "version": "1.3.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
+      "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
+      "requires": {
+        "unist-util-is": "2.1.1"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1521,12 +1846,42 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
       }
+    },
+    "vfile": {
+      "version": "2.3.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/vfile/-/vfile-2.3.0.tgz",
+      "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+      "requires": {
+        "is-buffer": "1.1.6",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "1.1.1",
+        "vfile-message": "1.0.0"
+      }
+    },
+    "vfile-location": {
+      "version": "2.0.2",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/vfile-location/-/vfile-location-2.0.2.tgz",
+      "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU="
+    },
+    "vfile-message": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/vfile-message/-/vfile-message-1.0.0.tgz",
+      "integrity": "sha512-HPREhzTOB/sNDc9/Mxf8w0FmHnThg5CRSJdR9VRFkD2riqYWs+fuXlj5z8mIpv2LrD7uU41+oPWFOL4Mjlf+dw==",
+      "requires": {
+        "unist-util-stringify-position": "1.1.1"
+      }
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
     "which": {
       "version": "1.3.0",
@@ -1553,6 +1908,21 @@
       "requires": {
         "mkdirp": "0.5.1"
       }
+    },
+    "x-is-function": {
+      "version": "1.0.4",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/x-is-function/-/x-is-function-1.0.4.tgz",
+      "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4="
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -166,7 +166,7 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
@@ -432,7 +432,7 @@
     },
     "error-ex": {
       "version": "1.3.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/error-ex/-/error-ex-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
@@ -784,7 +784,7 @@
     },
     "hosted-git-info": {
       "version": "2.5.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
@@ -867,7 +867,7 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
@@ -878,7 +878,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -1107,7 +1107,7 @@
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/jsonify/-/jsonify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
@@ -1239,7 +1239,7 @@
     },
     "normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
@@ -1620,7 +1620,7 @@
     },
     "spdx-correct": {
       "version": "1.0.2",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
@@ -1629,13 +1629,13 @@
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
       "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
       "dev": true
     },
     "spdx-license-ids": {
       "version": "1.2.2",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
@@ -1712,7 +1712,7 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
@@ -1846,7 +1846,7 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "acorn": {
       "version": "5.4.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/acorn/-/acorn-5.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
       "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
     },
     "acorn-jsx": {
@@ -26,7 +26,7 @@
     },
     "ajv": {
       "version": "5.5.2",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/ajv/-/ajv-5.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
         "co": "4.6.0",
@@ -65,13 +65,13 @@
     },
     "array-filter": {
       "version": "0.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/array-filter/-/array-filter-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
     },
     "array-includes": {
       "version": "3.0.3",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/array-includes/-/array-includes-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "requires": {
         "define-properties": "1.1.2",
@@ -80,13 +80,13 @@
     },
     "array-map": {
       "version": "0.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/array-map/-/array-map-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
       "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
       "dev": true
     },
     "array-reduce": {
       "version": "0.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/array-reduce/-/array-reduce-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
       "dev": true
     },
@@ -110,7 +110,7 @@
     },
     "asap": {
       "version": "2.0.6",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/asap/-/asap-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "babel-code-frame": {
@@ -147,7 +147,7 @@
     },
     "bail": {
       "version": "1.0.2",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/bail/-/bail-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
       "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q="
     },
     "balanced-match": {
@@ -156,9 +156,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -184,13 +184,13 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
     },
     "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+      "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
+        "supports-color": "5.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -202,33 +202,33 @@
           }
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
     },
     "character-entities": {
       "version": "1.2.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/character-entities/-/character-entities-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
       "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco="
     },
     "character-entities-legacy": {
       "version": "1.1.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
       "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8="
     },
     "character-reference-invalid": {
       "version": "1.1.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
       "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw="
     },
     "chardet": {
       "version": "0.4.2",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/chardet/-/chardet-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
     "circular-json": {
@@ -265,7 +265,7 @@
     },
     "collapse-white-space": {
       "version": "1.0.3",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
       "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw="
     },
     "color-convert": {
@@ -292,7 +292,7 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "typedarray": "0.0.6"
       }
     },
@@ -306,7 +306,7 @@
     },
     "core-js": {
       "version": "1.2.7",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/core-js/-/core-js-1.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "core-util-is": {
@@ -344,7 +344,7 @@
     },
     "define-properties": {
       "version": "1.1.2",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/define-properties/-/define-properties-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
         "foreach": "2.0.5",
@@ -367,7 +367,7 @@
     },
     "doctrine": {
       "version": "2.1.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/doctrine/-/doctrine-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "requires": {
         "esutils": "2.0.2"
@@ -403,9 +403,9 @@
       }
     },
     "domutils": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz",
-      "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "requires": {
         "dom-serializer": "0.1.0",
         "domelementtype": "1.3.0"
@@ -413,13 +413,13 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
     "encoding": {
       "version": "0.1.12",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/encoding/-/encoding-0.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
         "iconv-lite": "0.4.19"
@@ -441,7 +441,7 @@
     },
     "es-abstract": {
       "version": "1.10.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/es-abstract/-/es-abstract-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "requires": {
         "es-to-primitive": "1.1.1",
@@ -453,7 +453,7 @@
     },
     "es-to-primitive": {
       "version": "1.1.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "requires": {
         "is-callable": "1.1.3",
@@ -468,12 +468,12 @@
     },
     "eslint": {
       "version": "4.17.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/eslint/-/eslint-4.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.17.0.tgz",
       "integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
@@ -503,7 +503,7 @@
         "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
@@ -512,12 +512,12 @@
     },
     "eslint-config-google": {
       "version": "0.9.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/eslint-config-google/-/eslint-config-google-0.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.9.1.tgz",
       "integrity": "sha512-5A83D+lH0PA81QMESKbLJd/a3ic8tPZtwUmqNrxMRo54nfFaUvtt89q/+icQ+fd66c2xQHn0KyFkzJDoAUfpZA=="
     },
     "eslint-plugin-html": {
       "version": "4.0.2",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/eslint-plugin-html/-/eslint-plugin-html-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-4.0.2.tgz",
       "integrity": "sha512-CrQd0F8GWdNWnu4PFrYZl+LjUCXNVy2h0uhDMtnf/7VKc9HRcnkXSrlg0BSGfptZPSzmwnnwCaREAa9+fnQhYw==",
       "requires": {
         "htmlparser2": "3.9.2"
@@ -533,7 +533,7 @@
     },
     "eslint-plugin-markdown": {
       "version": "1.0.0-beta.6",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/eslint-plugin-markdown/-/eslint-plugin-markdown-1.0.0-beta.6.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-markdown/-/eslint-plugin-markdown-1.0.0-beta.6.tgz",
       "integrity": "sha1-2eYmZu6k52OH6F9QLfZoq9+9Q5U=",
       "requires": {
         "object-assign": "4.1.1",
@@ -543,7 +543,7 @@
     },
     "eslint-plugin-react": {
       "version": "7.6.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/eslint-plugin-react/-/eslint-plugin-react-7.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.6.1.tgz",
       "integrity": "sha512-30aMOHWX/DOaaLJVBHz6RMvYM2qy5GH63+y2PLFdIrYe4YLtODFmT3N1YA7ZqUnaBweVbedr4K4cqxOlWAPjIw==",
       "requires": {
         "doctrine": "2.1.0",
@@ -563,12 +563,12 @@
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
       "version": "3.5.3",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/espree/-/espree-3.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
       "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
       "requires": {
         "acorn": "5.4.1",
@@ -609,7 +609,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -629,12 +629,12 @@
     },
     "extend": {
       "version": "3.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/extend/-/extend-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "external-editor": {
       "version": "2.1.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/external-editor/-/external-editor-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
       "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "requires": {
         "chardet": "0.4.2",
@@ -659,7 +659,7 @@
     },
     "fbjs": {
       "version": "0.8.16",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/fbjs/-/fbjs-0.8.16.tgz",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "requires": {
         "core-js": "1.2.7",
@@ -701,12 +701,12 @@
     },
     "foreach": {
       "version": "2.0.5",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/foreach/-/foreach-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "from": {
       "version": "0.1.7",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/from/-/from-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
@@ -740,7 +740,7 @@
     },
     "globals": {
       "version": "11.3.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/globals/-/globals-11.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
       "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw=="
     },
     "globby": {
@@ -778,9 +778,9 @@
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -795,10 +795,10 @@
       "requires": {
         "domelementtype": "1.3.0",
         "domhandler": "2.4.1",
-        "domutils": "1.6.2",
+        "domutils": "1.7.0",
         "entities": "1.1.1",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "iconv-lite": {
@@ -836,7 +836,7 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "requires": {
         "ansi-escapes": "3.0.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.1.0",
@@ -853,12 +853,12 @@
     },
     "is-alphabetical": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
       "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg="
     },
     "is-alphanumerical": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
       "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
       "requires": {
         "is-alphabetical": "1.0.1",
@@ -873,7 +873,7 @@
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
@@ -887,17 +887,17 @@
     },
     "is-callable": {
       "version": "1.1.3",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-callable/-/is-callable-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
     },
     "is-date-object": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-date-object/-/is-date-object-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-decimal": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-decimal/-/is-decimal-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
       "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI="
     },
     "is-fullwidth-code-point": {
@@ -907,7 +907,7 @@
     },
     "is-hexadecimal": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
       "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk="
     },
     "is-path-cwd": {
@@ -925,7 +925,7 @@
     },
     "is-path-inside": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
         "path-is-inside": "1.0.2"
@@ -933,7 +933,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-promise": {
@@ -943,7 +943,7 @@
     },
     "is-regex": {
       "version": "1.0.4",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-regex/-/is-regex-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
         "has": "1.0.1"
@@ -951,27 +951,27 @@
     },
     "is-resolvable": {
       "version": "1.1.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-symbol/-/is-symbol-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-whitespace-character": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz",
       "integrity": "sha1-muAXbzKCtlRXoZks2whPil+DPjs="
     },
     "is-word-character": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/is-word-character/-/is-word-character-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.1.tgz",
       "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs="
     },
     "isarray": {
@@ -986,7 +986,7 @@
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
         "node-fetch": "1.7.3",
@@ -1091,7 +1091,7 @@
     },
     "json-parse-better-errors": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
       "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
       "dev": true
     },
@@ -1102,7 +1102,7 @@
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "jsonify": {
@@ -1113,7 +1113,7 @@
     },
     "jsx-ast-utils": {
       "version": "2.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
       "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
       "requires": {
         "array-includes": "3.0.3"
@@ -1130,7 +1130,7 @@
     },
     "load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
@@ -1142,7 +1142,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -1150,12 +1150,12 @@
     },
     "lodash": {
       "version": "4.17.5",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/lodash/-/lodash-4.17.5.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "loose-envify": {
       "version": "1.3.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/loose-envify/-/loose-envify-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
         "js-tokens": "3.0.2"
@@ -1172,24 +1172,24 @@
     },
     "map-stream": {
       "version": "0.1.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/map-stream/-/map-stream-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
     "markdown-escapes": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/markdown-escapes/-/markdown-escapes-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.1.tgz",
       "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg="
     },
     "memorystream": {
       "version": "0.3.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/memorystream/-/memorystream-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimatch": {
@@ -1197,7 +1197,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -1230,7 +1230,7 @@
     },
     "node-fetch": {
       "version": "1.7.3",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/node-fetch/-/node-fetch-1.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
         "encoding": "0.1.12",
@@ -1245,18 +1245,18 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
     "npm-run-all": {
       "version": "4.1.2",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/npm-run-all/-/npm-run-all-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.2.tgz",
       "integrity": "sha512-Z2aRlajMK4SQ8u19ZA75NZZu7wupfCNQWdYosIi8S6FgBdGf/8Y6Hgyjdc8zU2cYmIRVCx1nM80tJPkdEd+UYg==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "cross-spawn": "5.1.0",
         "memorystream": "0.3.1",
         "minimatch": "3.0.4",
@@ -1268,7 +1268,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
-          "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
@@ -1284,7 +1284,7 @@
     },
     "object-keys": {
       "version": "1.0.11",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/object-keys/-/object-keys-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
     "once": {
@@ -1323,7 +1323,7 @@
     },
     "parse-entities": {
       "version": "1.1.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/parse-entities/-/parse-entities-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
       "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
       "requires": {
         "character-entities": "1.2.1",
@@ -1336,7 +1336,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
@@ -1356,7 +1356,7 @@
     },
     "path-type": {
       "version": "3.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/path-type/-/path-type-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
@@ -1365,7 +1365,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -1373,7 +1373,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -1409,9 +1409,9 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "2.0.0",
@@ -1420,7 +1420,7 @@
     },
     "promise": {
       "version": "7.3.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/promise/-/promise-7.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "2.0.6"
@@ -1428,7 +1428,7 @@
     },
     "prop-types": {
       "version": "15.6.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/prop-types/-/prop-types-15.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
         "fbjs": "0.8.16",
@@ -1438,7 +1438,7 @@
     },
     "ps-tree": {
       "version": "1.1.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/ps-tree/-/ps-tree-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
       "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
       "dev": true,
       "requires": {
@@ -1452,7 +1452,7 @@
     },
     "read-pkg": {
       "version": "3.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/read-pkg/-/read-pkg-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
@@ -1462,14 +1462,14 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
+        "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
@@ -1477,7 +1477,7 @@
     },
     "remark-parse": {
       "version": "3.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/remark-parse/-/remark-parse-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-3.0.1.tgz",
       "integrity": "sha1-G5+EGkTY9PvyJGhQJlRZpOs1TIA=",
       "requires": {
         "collapse-white-space": "1.0.3",
@@ -1500,12 +1500,12 @@
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "replace-ext": {
       "version": "1.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/replace-ext/-/replace-ext-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "require-uncached": {
@@ -1566,13 +1566,13 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "shebang-command": {
@@ -1590,7 +1590,7 @@
     },
     "shell-quote": {
       "version": "1.6.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/shell-quote/-/shell-quote-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
@@ -1641,7 +1641,7 @@
     },
     "split": {
       "version": "0.3.3",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/split/-/split-0.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
@@ -1655,12 +1655,12 @@
     },
     "state-toggle": {
       "version": "1.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/state-toggle/-/state-toggle-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.0.tgz",
       "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU="
     },
     "stream-combiner": {
       "version": "0.0.4",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
@@ -1678,7 +1678,7 @@
     },
     "string.prototype.padend": {
       "version": "3.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
       "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
       "dev": true,
       "requires": {
@@ -1733,7 +1733,7 @@
       "requires": {
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
@@ -1759,17 +1759,17 @@
     },
     "trim": {
       "version": "0.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/trim/-/trim-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-trailing-lines": {
       "version": "1.1.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
       "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ="
     },
     "trough": {
       "version": "1.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/trough/-/trough-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.1.tgz",
       "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y="
     },
     "type-check": {
@@ -1787,12 +1787,12 @@
     },
     "ua-parser-js": {
       "version": "0.7.17",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
     },
     "unherit": {
       "version": "1.1.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/unherit/-/unherit-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
       "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
       "requires": {
         "inherits": "2.0.3",
@@ -1801,7 +1801,7 @@
     },
     "unified": {
       "version": "6.1.6",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/unified/-/unified-6.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.6.tgz",
       "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
       "requires": {
         "bail": "1.0.2",
@@ -1815,12 +1815,12 @@
     },
     "unist-util-is": {
       "version": "2.1.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/unist-util-is/-/unist-util-is-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.1.tgz",
       "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs="
     },
     "unist-util-remove-position": {
       "version": "1.1.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz",
       "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
       "requires": {
         "unist-util-visit": "1.3.0"
@@ -1828,12 +1828,12 @@
     },
     "unist-util-stringify-position": {
       "version": "1.1.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz",
       "integrity": "sha1-PMvcU2ee7W7PN3fdf14yKcG2qjw="
     },
     "unist-util-visit": {
       "version": "1.3.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
       "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
       "requires": {
         "unist-util-is": "2.1.1"
@@ -1856,7 +1856,7 @@
     },
     "vfile": {
       "version": "2.3.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/vfile/-/vfile-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
       "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
       "requires": {
         "is-buffer": "1.1.6",
@@ -1867,12 +1867,12 @@
     },
     "vfile-location": {
       "version": "2.0.2",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/vfile-location/-/vfile-location-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.2.tgz",
       "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU="
     },
     "vfile-message": {
       "version": "1.0.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/vfile-message/-/vfile-message-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.0.tgz",
       "integrity": "sha512-HPREhzTOB/sNDc9/Mxf8w0FmHnThg5CRSJdR9VRFkD2riqYWs+fuXlj5z8mIpv2LrD7uU41+oPWFOL4Mjlf+dw==",
       "requires": {
         "unist-util-stringify-position": "1.1.1"
@@ -1880,7 +1880,7 @@
     },
     "whatwg-fetch": {
       "version": "2.0.3",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
       "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
     "which": {
@@ -1911,17 +1911,17 @@
     },
     "x-is-function": {
       "version": "1.0.4",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/x-is-function/-/x-is-function-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/x-is-function/-/x-is-function-1.0.4.tgz",
       "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4="
     },
     "x-is-string": {
       "version": "0.1.0",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/x-is-string/-/x-is-string-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "https://nexus.outils.sti.usherbrooke.ca/repository/npm-group/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -1,21 +1,25 @@
 {
   "name": "eslint-config-udes",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "ESLint shareable config for the UdeS JavaScript style guide",
   "main": "index.js",
   "scripts": {
-    "format": "npm run format:js && npm run format:json",
-    "format:js": "eslint . --ext js,html --ignore-path .gitignore --fix",
-    "format:json": "eslint . --ext .json --ignore-path .gitignore --fix",
-    "lint": "npm run lint:js && npm run lint:json",
-    "lint:js": "eslint . --ext js,html --ignore-path .gitignore",
-    "lint:json": "eslint . --ext .json --ignore-path .gitignore"
+    "format": "npm-run-all format:*",
+    "format:js": "eslint . --ext js --fix",
+    "format:json": "eslint . --ext json --fix",
+    "format:markdown": "eslint . --ext md --fix",
+    "lint": "npm-run-all lint:*",
+    "lint:js": "eslint . --ext js",
+    "lint:json": "eslint . --ext json",
+    "lint:markdown": "eslint . --ext md"
   },
-  "pre-commit": [
-    "lint"
-  ],
   "files": [
-    "index.js"
+    "index.js",
+    "node-8.js",
+    "polymer-2.js",
+    "polymer-2-application.js",
+    "polymer-2-element.js",
+    "react.js"
   ],
   "repository": {
     "type": "git",
@@ -49,16 +53,14 @@
   },
   "homepage": "https://github.com/UdeS-STI/eslint-config-udes#readme",
   "devDependencies": {
-    "pre-commit": "^1.2.2"
+    "npm-run-all": "^4.1.2"
   },
   "dependencies": {
-    "eslint": "^4.10.0",
-    "eslint-plugin-html": "^3.2.2",
+    "eslint": "^4.17.0",
+    "eslint-config-google": "^0.9.1",
+    "eslint-plugin-html": "^4.0.2",
     "eslint-plugin-json": "^1.2.0",
-    "eslint-config-standard": "^10.2.1",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-node": "^5.2.1",
-    "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-standard": "^3.0.1"
+    "eslint-plugin-markdown": "^1.0.0-beta.6",
+    "eslint-plugin-react": "^7.6.1"
   }
 }

--- a/polymer-2-application.js
+++ b/polymer-2-application.js
@@ -1,0 +1,6 @@
+module.exports = {
+  // Extends the UdeS ESLint config
+  extends: [
+    './polymer-2.js',
+  ],
+};

--- a/polymer-2-element.js
+++ b/polymer-2-element.js
@@ -25,6 +25,9 @@ module.exports = {
 
     // Enforce valid JSDoc comments
     'valid-jsdoc': ['error', {
+      // Use @return instead of @returns
+      prefer: {returns: 'return'},
+
       // If and only if the function or method has a return statement [See pull request #1]
       requireReturn: false,
     }],

--- a/polymer-2-element.js
+++ b/polymer-2-element.js
@@ -26,7 +26,7 @@ module.exports = {
     // Enforce valid JSDoc comments
     'valid-jsdoc': ['error', {
       // Use @return instead of @returns
-      prefer: {returns: 'return'},
+      prefer: { returns: 'return' },
 
       // If and only if the function or method has a return statement [See pull request #1]
       requireReturn: false,

--- a/polymer-2-element.js
+++ b/polymer-2-element.js
@@ -1,0 +1,32 @@
+module.exports = {
+  // Extends the UdeS ESLint config
+  extends: [
+    './polymer-2.js',
+  ],
+
+  // Custom rules
+  rules: {
+    // Require JSDoc comments
+    'require-jsdoc': [
+      'error', {
+        // Requires JSDoc comments for the specified nodes
+        'require': {
+          // Class Foo
+          'ClassDeclaration': true,
+
+          // function foo() {}
+          'FunctionDeclaration': true,
+
+          // constructor() {} [See pull request #1]
+          'MethodDefinition': false,
+        },
+      },
+    ],
+
+    // Enforce valid JSDoc comments
+    'valid-jsdoc': ['error', {
+      // If and only if the function or method has a return statement [See pull request #1]
+      requireReturn: false,
+    }],
+  },
+};

--- a/polymer-2.js
+++ b/polymer-2.js
@@ -4,6 +4,12 @@ module.exports = {
     './index.js',
   ],
 
+  // Defines global variables that are predefined
+  env: {		   
+    // Browser global variables		
+    browser: true,
+  },
+
   // Use of third-party plugins
   plugins: [
     // Allows linting and fixing inline scripts contained in HTML files

--- a/polymer-2.js
+++ b/polymer-2.js
@@ -1,0 +1,35 @@
+module.exports = {
+  // Extends the UdeS ESLint config
+  extends: [
+    './index.js',
+  ],
+
+  // Use of third-party plugins
+  plugins: [
+    // Allows linting and fixing inline scripts contained in HTML files
+    'eslint-plugin-html',
+  ],
+
+  // Custom rules
+  rules: {
+    // Require constructor names to begin with a capital letter
+    'new-cap': [
+      'error', {
+        // Allows specified uppercase-started function names to be called without the new operator
+        capIsNewExceptions: ['Polymer'],
+
+        // Allows any uppercase-started function names that match the specified regex pattern to be called without the
+        // new operator
+        capIsNewExceptionPattern: '^(UdeS|Polymer)',
+      }],
+  },
+
+  // Variables that are accessed but not defined within the same file
+  globals: {
+    // UdeS components and global scoped variables
+    UdeS: true,
+
+    // Polymer components and global scoped variables
+    Polymer: false,
+  },
+};

--- a/polymer-2.js
+++ b/polymer-2.js
@@ -5,8 +5,8 @@ module.exports = {
   ],
 
   // Defines global variables that are predefined
-  env: {		   
-    // Browser global variables		
+  env: {
+    // Browser global variables
     browser: true,
   },
 

--- a/react.js
+++ b/react.js
@@ -4,12 +4,14 @@ module.exports = {
     './index.js',
   ],
 
+  // Use of third-party plugins
+  plugins: [
+    'eslint-plugin-react',
+  ],
+
   // Defines global variables that are predefined
   env: {
     // Node.js global variables and Node.js scoping
     node: true,
   },
-
-  // Limit ESLint to a specific project
-  root: true,
 };

--- a/react.js
+++ b/react.js
@@ -20,6 +20,9 @@ module.exports = {
 
   // Custom rules
   rules: {
+    'react/jsx-uses-react': 'error',
     'react/jsx-uses-vars': 'error',
+    'react/no-unused-prop-types': 'error',
+    'react/require-default-props': 'error',
   },
 };

--- a/react.js
+++ b/react.js
@@ -11,6 +11,9 @@ module.exports = {
 
   // Defines global variables that are predefined
   env: {
+    // Browser global variables
+    browser: true,
+
     // Node.js global variables and Node.js scoping
     node: true,
   },

--- a/react.js
+++ b/react.js
@@ -14,4 +14,9 @@ module.exports = {
     // Node.js global variables and Node.js scoping
     node: true,
   },
+
+  // Custom rules
+  rules: {
+    'react/jsx-uses-vars': 'error',
+  },
 };


### PR DESCRIPTION
- Ajout du fichier .editorconfig
- Séparation de la configuration ESLint en plusieurs morceaux : 
  - Application Polymer 2
  - Élément Polymer 2
  - Application Node.js 8
  - Application React
- Règles pour enforcer le .editorconfig ont été ajoutées
- Utilisation de eslint:recommended et de Google comme React nécessite absolument des points virgules et pour des raisons de performances

@jfbelisle @Hailtothebreak @javamaniac @katima-g33k 