### PR TITLE
Mise-à-jour des dépendances et relâche de la version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udes",
-  "version": "0.4.3",
+  "version": "1.0.0",
   "description": "ESLint shareable config for the UdeS JavaScript style guide",
   "keywords": [
     "check",
@@ -59,26 +59,26 @@
   "prettier": "prettier-config-udes",
   "dependencies": {
     "babel-eslint": "^10.1.0",
-    "eslint": "^7.10.0",
-    "prettier-config-udes": "0.0.6"
+    "eslint": "^7.20.0",
+    "prettier-config-udes": "^1.0.0"
   },
   "devDependencies": {
     "eslint-plugin-json-format": "^2.0.1",
     "eslint-plugin-markdown": "^1.0.2",
-    "eslint-plugin-prettier": "^3.1.4",
-    "husky": "^4.3.0",
-    "lint-staged": "^10.4.0",
+    "eslint-plugin-prettier": "^3.3.1",
+    "husky": "^5.0.9",
+    "lint-staged": "^10.5.4",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.1.2"
+    "prettier": "^2.2.1"
   },
   "peerDependencies": {
-    "eslint-formatter-gitlab": "^2.0.0",
-    "eslint-plugin-html": "^6.1.0",
+    "eslint-formatter-gitlab": "^2.2.0",
+    "eslint-plugin-html": "^6.1.1",
     "eslint-plugin-json-format": "^2.0.1",
-    "eslint-plugin-lit": "^1.2.2",
+    "eslint-plugin-lit": "^1.3.0",
     "eslint-plugin-markdown": "^1.0.2",
-    "eslint-plugin-prettier": "^3.1.4",
-    "eslint-plugin-react": "^7.21.2",
-    "prettier": "^2.1.2"
+    "eslint-plugin-prettier": "^3.3.1",
+    "eslint-plugin-react": "^7.22.0",
+    "prettier": "^2.2.1"
   }
 }


### PR DESCRIPTION
https://github.com/UdeS-STI/prettier-config-udes/pull/5 devra être mergé avant celle-ci par contre.