### PR TITLE
Support ESLint 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-udes",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "ESLint shareable config for the UdeS JavaScript style guide",
   "keywords": [
     "check",

--- a/package.json
+++ b/package.json
@@ -55,15 +55,15 @@
   "prettier": "prettier-config-udes",
   "dependencies": {
     "babel-eslint": "^10.1.0",
-    "eslint": "^7.32.0",
-    "prettier-config-udes": "^1.0.0"
+    "eslint": "^8.0.1",
+    "prettier-config-udes": "^1.0.2"
   },
   "devDependencies": {
     "eslint-plugin-json-format": "^2.0.1",
     "eslint-plugin-markdown": "^2.2.1",
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.2",
-    "lint-staged": "^11.1.2",
+    "lint-staged": "^11.2.3",
     "npm-check-updates": "^11.8.5",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1"
@@ -72,10 +72,10 @@
     "eslint-formatter-gitlab": "^2.2.0",
     "eslint-plugin-html": "^6.2.0",
     "eslint-plugin-json-format": "^2.0.1",
-    "eslint-plugin-lit": "^1.5.1",
+    "eslint-plugin-lit": "^1.6.0",
     "eslint-plugin-markdown": "^2.2.1",
     "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-react": "^7.26.0",
+    "eslint-plugin-react": "^7.26.1",
     "prettier": "^2.4.1"
   }
 }


### PR DESCRIPTION
ESLint v8.0.0 is [released](https://eslint.org/blog/2021/10/eslint-v8.0.0-released) :tada: 

peerDependencies compatibility with ESLint 8:
  - [ ] **[eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react)**: https://github.com/yannickcr/eslint-plugin-react/pull/3059
  - [x] **[eslint-formatter-gitlab](https://gitlab.com/remcohaszing/eslint-formatter-gitlab)**:  [Add Support for ESLint v8](https://gitlab.com/remcohaszing/eslint-formatter-gitlab/-/merge_requests/36)